### PR TITLE
Add third-party-02 repo

### DIFF
--- a/hiconic-sdk/res/hiconic-sdk/conf/templates/repository-configuration-devenv-hiconic-os.yaml
+++ b/hiconic-sdk/res/hiconic-sdk/conf/templates/repository-configuration-devenv-hiconic-os.yaml
@@ -25,5 +25,10 @@
       name: "third-party",
       url: "https://repo1.maven.org/maven2/",
     },
+    # Required at least by com.github.Cloudmersive:Cloudmersive.APIClient.Java
+    !com.braintribe.devrock.model.repository.MavenHttpRepository {
+      name: "third-party-02",
+      url: "https://repository.liferay.com/nexus/content/repositories/public/",
+    },
   ]
 }


### PR DESCRIPTION
Cloudmersive artifacts are in another 3rd party repository. Without the additional repo there will be an error like below when building with below command.

```
jinni build-docker-images \
    --dockerImageTag $(date +"%Y%m%d%H%M") \
    --dockerRegistryHost "$docker_registry_host" \
    --dockerRegistrySubfolder "$docker_registry_subfolder" \
    --setupDependency "tribefire.extension.meta.self-diagnosis:popular-modules-setup#1.0"
``` 

```
ERROR: IncompleteResolution: Incomplete resolution for terminals tribefire.extension.antivirus:antivirus-module#3.0.3
- IncompleteArtifactResolution: Incomplete resolution of artifact tribefire.extension.antivirus:antivirus-connector#3.0.5
  - UnresolvedDependency: Unresolved dependency com.github.Cloudmersive:Cloudmersive.APIClient.Java#4.35/:jar
```